### PR TITLE
Write tags for insert queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 authors = ["Clemens Tiedt <clemens.tiedt@student.hpi.de>"]
-description = "A Rust library to interact with InfluxDB"
 edition = "2018"
-license = "MIT"
 name = "influx-client"
-repository = "https://github.com/ctiedt/influx_client"
 version = "0.4.0"
+description = "A Rust library to interact with InfluxDB"
+license = "MIT"
+repository = "https://github.com/ctiedt/influx_client"
 
 [dependencies]
 csv = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 authors = ["Clemens Tiedt <clemens.tiedt@student.hpi.de>"]
-edition = "2018"
-name = "influx-client"
-version = "0.4.0"
 description = "A Rust library to interact with InfluxDB"
+edition = "2018"
 license = "MIT"
+name = "influx-client"
 repository = "https://github.com/ctiedt/influx_client"
+version = "0.4.0"
 
 [dependencies]
 csv = "1.1"
 futures = "0.3"
-itertools = "0.10.5"
 num-traits = "0.2"
 reqwest = {version = "0.11", features = ["blocking"]}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/ctiedt/influx_client"
 [dependencies]
 csv = "1.1"
 futures = "0.3"
+itertools = "0.10.5"
 num-traits = "0.2"
 reqwest = {version = "0.11", features = ["blocking"]}
 

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, io::Read};
 
 use csv::StringRecord;
+use itertools::Itertools;
 
 use crate::{InfluxError, Precision, ReadQuery, WriteQuery};
 
@@ -49,8 +50,15 @@ impl<'a> Client<'a> {
             ))
             .header("Authorization", &format!("Token {}", self.token))
             .body(format!(
-                "{} {}={}",
-                query.name, query.field_name, query.value
+                "{}{} {}={}",
+                query.name,
+                query
+                    .tags
+                    .iter()
+                    .map(|(key, val)| format!(",{}={}", key, val))
+                    .join(""),
+                query.field_name,
+                query.value
             ))
             .send()
             .map_err(|e| InfluxError {

--- a/src/blocking/client.rs
+++ b/src/blocking/client.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Display, io::Read};
 
 use csv::StringRecord;
-use itertools::Itertools;
 
 use crate::{InfluxError, Precision, ReadQuery, WriteQuery};
 
@@ -56,7 +55,7 @@ impl<'a> Client<'a> {
                     .tags
                     .iter()
                     .map(|(key, val)| format!(",{}={}", key, val))
-                    .join(""),
+                    .collect::<String>(),
                 query.field_name,
                 query.value
             ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use std::fmt::Display;
 
 use csv::StringRecord;
 pub use flux::{Precision, ReadQuery, WriteQuery};
-use itertools::Itertools;
 use futures::TryFutureExt;
 
 #[derive(Debug)]
@@ -63,7 +62,11 @@ impl<'a> Client<'a> {
             .body(format!(
                 "{}{} {}={}",
                 query.name,
-                query.tags.iter().map(|(key,val)| format!(",{}={}", key, val)).join(""),
+                query
+                    .tags
+                    .iter()
+                    .map(|(key, val)| format!(",{}={}", key, val))
+                    .collect::<String>(),
                 query.field_name,
                 query.value
             ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::fmt::Display;
 
 use csv::StringRecord;
 pub use flux::{Precision, ReadQuery, WriteQuery};
+use itertools::Itertools;
 use futures::TryFutureExt;
 
 #[derive(Debug)]
@@ -60,8 +61,11 @@ impl<'a> Client<'a> {
             ))
             .header("Authorization", &format!("Token {}", self.token))
             .body(format!(
-                "{} {}={}",
-                query.name, query.field_name, query.value
+                "{}{} {}={}",
+                query.name,
+                query.tags.iter().map(|(key,val)| format!(",{}={}", key, val)).join(""),
+                query.field_name,
+                query.value
             ))
             .send()
             .map_err(|e| InfluxError {


### PR DESCRIPTION
Hi, this change will add tags to the write request according Influx's "[Line protocol](https://docs.influxdata.com/influxdb/v2.6/reference/syntax/line-protocol/)":
```
<measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]
```
I added the `itertools` dependency in order to be able to `join` the strings inline. I'll leave it up to you to decide if you think that is a worthwhile dependency. As I understand it, the itertools library will eventually be part of the standard library.